### PR TITLE
Add The Hoskinsons

### DIFF
--- a/verified.json
+++ b/verified.json
@@ -39,5 +39,18 @@
         "policies": [
             "89fa6dc66a24799ccaee43a3a16930bb045a8152fdf2a2642034774f"
         ]
+    },
+    {
+        "project": "The Hoskinsons",
+        "tags": ["Hoskinsons", "hosk", "microhosk", "millihosk", "kilohosk", "megahosk", "gigahosk",
+                 "The Timeless Art of Decentralization", "Man in Library", "Warm Sunny Hoth", "Hosk Pool"],
+        "policies": [
+            "e986d38f4ead45a4f909cb51d61d8d95efc72b12d9302cdd040974d1",
+            "98dc68b04026544619a251bc01aad2075d28433524ac36cbc75599a1",
+            "bb1555e0c2e3fdf057a628c08e3e7d0ea16004e08c8d68670f636b32",
+            "899f355ac4222fefb0be7b05dd4766e95ce2e0dabed82c7ec56beb90",
+            "b1a60dbc60615e35dca949745b7fa15ceac192249fdaed486e5d43db",
+            "44ae79bd8fbbcd4b7ecbf5745feaa75feb4c7be8ac5198a968528f0a"
+        ]
     }
 ]


### PR DESCRIPTION
Hi! Thanks for adding this feature. We have 6 active policy IDs which I added as a single entry in verified.json. Assuming that "project" is the name of the project as it should be displayed on cnft.io, "tags" are keywords found in the name field of the NFTs metadata, and "policies" are all the valid policy IDs. Here are the 6 policy IDs I added with a brief description of the NFTs and tokens contained in each one. All of this can be verified at http://thehoskinsons.com/faq as well. Thanks!

- e986d38f4ead45a4f909cb51d61d8d95efc72b12d9302cdd040974d1 = 10000 NFTs with name "Hoskinsons #____"
- 98dc68b04026544619a251bc01aad2075d28433524ac36cbc75599a = fungible tokens with name "hosk," "kilohosk," "megahosk," etc
- bb1555e0c2e3fdf057a628c08e3e7d0ea16004e08c8d68670f636b32 = 5 NFTs with name "The Timeless Art of Decentralization (_ of 5)"
- 899f355ac4222fefb0be7b05dd4766e95ce2e0dabed82c7ec56beb90 = 5 NFTs with name "Man in Library (_ of 5)"
- b1a60dbc60615e35dca949745b7fa15ceac192249fdaed486e5d43db = 1 NFT with name "Warm Sunny Hoth"
- 44ae79bd8fbbcd4b7ecbf5745feaa75feb4c7be8ac5198a968528f0a = multiple NFTs with name "Hosk Pool ____" (e.g., "Hosk Pool Donkey #__," "Hosk Pool O.G.," "Hosk Pool Whale Award," etc