### PR TITLE
Adding Canuckz NFT project to PolicyID database

### DIFF
--- a/Canuckz
+++ b/Canuckz
@@ -1,0 +1,13 @@
+{
+    "project": "Canuckz NFT",
+    "tags": [
+        "Canuckz",
+        "CanuckzBeaver",
+        "CanuckzMoose",
+        "CanuckzRaccoon"
+    ],
+    "policies": [
+        "32f13cdaa51c1ea28221a9f656c498f1d05f7bda49d324d6ff0ad976",
+        "6e3f5e11921e3d337504a0dc89edded6f52adf0df97d712afaec7ade"
+    ]
+}


### PR DESCRIPTION
Adding Canuckz NFT

Project website with Policy IDs: https://canuckz-nft.io/about