### PR TITLE
Update CryptoFruits

### DIFF
--- a/CryptoFruits
+++ b/CryptoFruits
@@ -1,38 +1,7 @@
 [{
-		"project": "CryptoFruitBananaPOPSilver",
+		"project": "CryptoFruitPopSeries",
 		"policies": [
-			"0794598abb56ba0a587b9a7c7978af148e52ac37fb479894ac990f04",
-			"c85e7c8b2a7f9bac506249e49c2f0ac96cd23f6150858c54c13849df"
-
-		]
-	},
-	{
-		"project": "CryptoFruitBananaPOPGold",
-		"policies": [
-			"d5d13dd4dfb6faf6ead994ab8a27224e66d41a7ccd36ada9205fce81",
-			"1b17d5422da1cdb3bd4f5a330703be89596d694bd4acd656f66855f6"
-		]
-	},
-	{
-		"project": "CryptoFruitEggplantPOPSilver",
-		"policies": [
-			"5a72a4cbbf3432c48bec2901493791ce64a6f921d7dcc66e3b97dbe4",
-			"690af92f61f702ec3cc45c4fec4b95c80014a4592dc04bcce739e9b1"
-
-		]
-	}, {
-		"project": "CryptoFruitBananaPOPXADABOY",
-		"policies": [
-			"59171494bd93476bd0ece1fc9ba18e79199c5778086a69864af92ffc",
-			"366895ee399f5271f50176dc0352e77a0e46556d00144aad57afdaec"
-		]
-	},
-
-	{
-		"project": "CryptoFruitEggplantPOPGold",
-		"policies": [
-			"0485f571482bf8b804ee21ec88f72d4fddc9e71266642765ffe80d62",
-			"941eea88734448ac8ba1f8eaa1599ef869672adca7985e0f5304b452"
+			"8023e79397e3e8a367ab269390e070aee20328b0177515aafa0d7ff3"
 		]
 	}
 ]


### PR DESCRIPTION
All old Policies are now void. This is the new policy number for the pop series of cryptofruit. The original issue was the tokens were copies of eachother. Now all NFTS are unique, numbered and share a single policy number.