### PR TITLE
Added Bitlands

### DIFF
--- a/Bitlands
+++ b/Bitlands
@@ -1,0 +1,13 @@
+{
+    "project": "Bitlands",
+    "tags": [
+        "BTLND0",
+        "BTLND",
+        "Bitlands",
+        "Bitlands0",
+        "Bitlands0x"
+    ],
+    "policies": [
+        "ca3aeaa53c0b21fccf28c8c724141473d325fe9ea8d0314f7c3b4240"
+    ]
+}


### PR DESCRIPTION
Added Bitlands Project.
Website: https://bitlands.art (In the FAQ section)

This policy will time-lock. The policy for the first 1k (sold out) gen0 islands is not locked. That's why I could not verify it on CNFT.IO. If it is still possible it would be awesome for the community.