### PR TITLE
CARDANO CATZ (second attempt)

### DIFF
--- a/CARDANO CATZ
+++ b/CARDANO CATZ
@@ -1,0 +1,9 @@
+{
+    "project": "CARDANO CATZ",
+    "tags": [
+        "CARDANO CATZ"
+    ],
+    "policies": [
+        "bf161ad16b041a65dde961a020ce783a42f2c77950882bb71ab46a11"
+    ]
+}


### PR DESCRIPTION
Hi, I am doing a second attempt here.
During the last attempt, the verification of this policy was not accepted because the policy never locks: https://github.com/Cardano-NFTs/policyIDs/pull/453

As said in the exchange of messages:
1) it is not mentioned anywhere that the policy needs to lock
2) the keys of the policy are held by easycnft.art and are now destroyed (the owner @vmlinuz1974 can confirm on Twitter)
3) the series 2 will be issued shortly and this time I will use a locked policy

I hope that you understand my point of view and that you will be able to make an exception for this case.
Only 126 tokens have been minted on this non-locked policy and I am not able to mint any additional ones:  https://cardanoscan.io/tokenPolicy/bf161ad16b041a65dde961a020ce783a42f2c77950882bb71ab46a11

Thanks :)
I have sent many messages to Stale on Twitter without success.