### PR TITLE
Update PBHP Policy ID to single policy ID for series

### DIFF
--- a/Punk Baby House Party
+++ b/Punk Baby House Party
@@ -5,11 +5,24 @@
             "PBHP",
             "PBHP Cardano Gen",
             "PBHP Baby Chuck",
+            "PBHP Baby Charles,
             "PBHP Shelley Gen",
             "PBHP Mary Gen",
             "PBHP Alonzo Gen",
             "PBHP Goguen Gen",
             "Punk Baby House Party"
+        ],
+        "policies": [
+            "2a883299e372b899fc869765d5960445cb626396883d674114f11e7c",
+            "c7538e4326fc931f96f0879f1841100b1812ef247d43d9d5af22bb9e",
+            "ddef4717f37976a23020e2b9341a83d8dfa1f3804709c245d34a2199"
+        ]
+    },
+    
+    {
+        "project": "PBHP Cardano Gen",
+        "tags": [
+            
         ],
         "policies": [
             "6aa1e701a9759f9120e35530f71bbba13b3a9a2d3700831e10038039",


### PR DESCRIPTION
Let's hope this works...

After learning of my novice mistake regarding the copious number of policy IDs for Punk Baby House Party we have embarked upon a new era... hopefully.

This commit will move all of the current policies to live under the PBHP Cardano Gen project for now.

Meanwhile the Punk Baby House Party project has been changed to only include 3 new policy IDs and will at the end of its lifespan have a total of 6 policy IDs. Each ID corresponding to a specific series. 

The 3 series included in this commit are for Cardano Gen, Baby Chuck/Charles, and Shelley Gen which will be released at the end of September (hopefully).

Over the coming weeks we will be reaching out to all of the current owners of PBHP babies and enticing them with some sweet prizes if they swap out their babies and receive a fresh one under the new single policy ID associated with their series.

From time to time as we burn the old babies and replace them with fresh ones we will update this file to remove the no longer valid policies and hopefully delete the PBHP Cardano Gen project entirely.

If I'm still missing something essential, something that would make these changes not effective in achieving my goals, please let me know. My goal is to have the project able to function in the project filter so that people can find the NFTs and so that we will be able to use some of the various CNFT tracking tools that exist.

Thank you!