### PR TITLE
Add singular form of SushiByte in tags

### DIFF
--- a/SushiBytes
+++ b/SushiBytes
@@ -1,7 +1,8 @@
 {
     "project": "SushiBytes",
     "tags": [
-        "SushiBytes"
+        "SushiBytes",
+        "SushiByte"
     ],
     "policies": [
          "cd4f09ef0a8f9a3557903d2c9a45b2f6198f1267c2031bc9228ed74a",


### PR DESCRIPTION
Add singular form, "SushiByte", in tags as this is common.