### PR TITLE
Added Crypto News Website

### DIFF
--- a/Crypto News Website
+++ b/Crypto News Website
@@ -1,0 +1,6 @@
+{
+    "project": "Crypto News Website",
+    "policies": [
+        "13bd54606d893a61236d0967de96ec8a65d919058fd7b2ea59968758"
+    ]
+}


### PR DESCRIPTION
We are a small web design agency specialized in building news websites with automating posting for crypto-news niche. 

https://cryptonewspros.club/ - our main website
https://bestcryptonews.club/ - a redirect to our main website

Instagram: https://www.instagram.com/catalin_cryptonewspros/
Email: contact@cryptonewspros.club