### PR TITLE
Create Cadambabo NFTs

### DIFF
--- a/Cadambabo NFTs
+++ b/Cadambabo NFTs
@@ -1,0 +1,9 @@
+{
+    "project": "Cadambabo NFTs",
+    "tags": [
+        "Cadambabo NFTs"
+    ],
+    "policies": [
+        "064ae297a28f04d3f2d4b322c0a8af6e0eec675b3485cc849b99cc2b"
+    ]
+}


### PR DESCRIPTION
Cadambabo NFTs is creating a series of authentic artwork made by hand, the project is to make mostly 1 of a kind original NFT artwork,
there are projects in the Cardano ecosystem that will get Cadambabo NFTs as a gift to their team members to show appreciation for their work, in this case, some Cadambabo NFTs will have multiples but specifically for the team members,
heres an example: if Cadambabo NFTs decides to make a project's team members their own NFTs as a gift, if there are 10 members there will be 10 of that same NFT minted and numbered accordingly.