### PR TITLE
Added Cutisaurus Park project

### DIFF
--- a/CutisaurusPark
+++ b/CutisaurusPark
@@ -1,0 +1,9 @@
+{
+    "project": "Cutisaurus Park",
+    "tags": [
+        "Cutisaurus"
+    ],
+    "policies": [
+        "2c59b54c7ba20d88160e378f832c725fc631b809d13977aaca466808"
+    ]
+}


### PR DESCRIPTION
Owner of Cutisaurus Park project. Currently listed on CNFT.

Twitter handle: @Cutisaurus
Newly created Discord: https://discord.gg/NtD6d8s5

Please verify Cutisaurus Park project. 
Thank you.