### PR TITLE
Add Steve3p_0 to be a Verified Policy ID

### DIFF
--- a/Steve3p_0
+++ b/Steve3p_0
@@ -1,0 +1,10 @@
+[
+    {
+        "project": "Steve3p_0",
+        "tags" : {Steve3p_0,
+            "Steve3p_0"
+        "policies": [
+            "8dbef3ae32a5ac935172ab84cb7a3540603207892c9ab63956490086",
+        ]
+    },
+]


### PR DESCRIPTION
I realized last commit that I should Only have one Policy. I am currently reminting all 85 of my NFT's onto this unlocked policy. Please feel free to contact me if you have any questions Twitter : https://twitter.com/Steve_3p0_