### PR TITLE
Create CardanoBotz

### DIFF
--- a/CardanoBotz
+++ b/CardanoBotz
@@ -1,0 +1,12 @@
+{
+    "project": "CardanoBotz",
+    "tags": [
+        "CardanoBotz"
+    ],
+    "policies": [
+              "be20ca484e67f733fc3ac5e40f47efc256095279e5e61f1aab5622c9"
+          ]
+}
+
+
+


### PR DESCRIPTION
Adding our new project CardanoBotz to CNFT and our first NFT policy ID (verifiable via our website CardanoBotz.io)