### PR TITLE
Add The Cardano Clowns

### DIFF
--- a/TheCardanoClowns
+++ b/TheCardanoClowns
@@ -1,0 +1,9 @@
+{
+    "project": "TheCardanoClowns",
+    "tags": [
+        "TheCardanoClowns"
+    ],
+    "policies": [
+        "807fc28247e6837792ed8b9cee0183c962527d3965cb80a682bb4f80"
+    ]
+}


### PR DESCRIPTION
Policy ID is published on https://thecardanoclowns.com/ / https://twitter.com/cardano_clowns.