### PR TITLE
PunksterArt OG Policy ID added

### DIFF
--- a/PunksterArt
+++ b/PunksterArt
@@ -2,5 +2,6 @@
     "project": "PunksterArt",
     "policies": [
         "84c0acb101c14416ad92859c429058871e201804468d5f353be31d71",
+        "b06b5ff1466c327853020195e5f7c19994806bad8961817a68ca7cd1"
     ]
 }


### PR DESCRIPTION
Added the policy id for a medal created for OG

Proof of Policy ID for OG Medals: https://twitter.com/PunksterA/status/1442808198994477057
