### PR TITLE
Added the policy id for IELE

### DIFF
--- a/Icons
+++ b/Icons
@@ -1,6 +1,7 @@
 {
     "project": "Icons",
     "policies": [
-        "3f72283d65c97eb73d987777965e5f756d4c7c01e93e202042738229"
+        "3f72283d65c97eb73d987777965e5f756d4c7c01e93e202042738229",
+        "0ce835ee4c7bffe6ea3cd59fbf69303fc3c255bb32c879a08c903f41"
     ]
 }


### PR DESCRIPTION
The 4th piece of the Icons collection, IELE, was airdrop to holders of a full set of the initial pieces in the collection.
IELE was minted under a new policy id.