### PR TITLE
Approve 0xDEADBEEF policyid

### DIFF
--- a/0xDEADBEEF
+++ b/0xDEADBEEF
@@ -1,0 +1,9 @@
+{
+    "project": "0xDEADBEEF",
+    "tags": [
+        "0xDEADBEEF"
+    ],
+    "policies": [
+        "deadbeefc94da8c9c890c213165480206fd0617130f13c9dd3c1270e"
+    ]
+}


### PR DESCRIPTION
This project exists solely because it uses the vanity policyid starting with 'deadbeef'. Please advise if there are any alternative ways to verify this policyid, as an official twitter/website does not currently exist.

Existing tokens can be found here: https://pool.pm/addr1q9afhw5v8rkydmvd34kl6mjvllr58lsf8kjv8wnyftf73g4utnxgcn0srryfpc4tmlq0n9lr9w5uhzqax88dneyhs48q84wugk/deadbeef

The policy script has already expired, and no further tokens can be created.