### PR TITLE
Update Cardenia to Cardenia City

### DIFF
--- a/Cardenia
+++ b/Cardenia
@@ -1,6 +1,11 @@
 {
-    "project": "Cardenia",
+    "project": "Cardenia City",
+    "tags": [
+        "Cardenia",
+        "Cardenians",
+        "Cardenia City"
+    ],
     "policies": [
         "01d63b5dc783794a49d8369ec754306660c6ef1c18310c1ceb350b28"
-    ]
+          ]
 }


### PR DESCRIPTION
apparently the filter system in cnft.io doesn't detect words other than Cardenia, as there is a project with a similar name we are requesting to update the name and insert tags related to the project.