### PR TITLE
adding Cardano420 project

### DIFF
--- a/cardano420
+++ b/cardano420
@@ -1,0 +1,9 @@
+{
+    "project": "Cardano420",
+    "tags": [
+        "OGCollection", "Cardano420"
+    ],
+    "policies": [
+        "6240aa2abaa41c6ca0649da76cc3da646752aff0e742ec88412eb56b"
+    ]
+}


### PR DESCRIPTION
Adding Cardano420 Project.

PolicyID can be found on official drop page here: https://buynfts.cardano420.com/