### PR TITLE
updated project name as per re-branding

### DIFF
--- a/RobTheRobot
+++ b/RobTheRobot
@@ -1,7 +1,7 @@
 {
-    "project": "Rob-the-Robot",
+    "project": "CardanoBotikz",
     "tags": [
-        "RobTheRobot"
+        "RobTheRobot", "CardanoBotikz-Rob", "CardanoBotikz-Robyn"
     ],
     "policies": [
         "5380c1fe80547a9317dbd4f45cb92d57e320f4bb93a467a7c98e0892"


### PR DESCRIPTION
Updating project name as per re-branding.

New project name can be seen on official webpage here along with existing policyID which has not changed.

https://www.ada-nfts.com/