### PR TITLE
Delete policy that was double minted by NFT-maker.io

### DIFF
--- a/NationsADA
+++ b/NationsADA
@@ -7,7 +7,6 @@
         "a0c45879d1fdfc2b3d0ed717502ec4a0ad44b789c19d4f5f0a5c22a2",
               "ac77db6f45c21a77d6cc0638f3b02f92c25d703ebf2097ca12511248",
               "605bcc0236eaa85af2a4c025049d6ecd8b948dcf7b6010e49cffd7d2",
-              "94a4ca78fade2f19952dddbc646bb856ad6dd4bea6bc80d2f87259ac",
               "2331b3d789ddca2f42b50f81bdcecd32c3a45c4f2f621995b213e011",
               "cfd6eba2303585bb8df4218791338951fcc916dfa2f621b63510c092"
           ]


### PR DESCRIPTION
This is done so tha a NFT that doesnt belong to our project won't show as ours in the marketplace.