### PR TITLE
Added CardanoRum for Verification

### DIFF
--- a/CardanoRum
+++ b/CardanoRum
@@ -1,0 +1,15 @@
+{
+    "project": "Cardano Rum by JorgePool.com",
+    "tags": [ 
+        "CardanoRum",
+		"CardanoRums",
+        "RumCoupon",
+        "RumCertificate",
+        "Rum",
+        "HodlTheBodl",
+        "HodlDaBodl"
+    ],
+    "policies": [
+        "0694ecce7e95bedd98959dbe1f744b9e2aa479346735ab744b7d3fb5"
+    ]
+}


### PR DESCRIPTION
CardanoRum NFTs are the Digital Double for The Physical Bottles of Cardano Rum Commemorating the Alonzo Hard Fork and the 6 year anniversary of the launch of Cardano by Charles Hoskinson back in September 2015. Not to be confused with the ADA token itself which was launched two years later in September 2017. We chose one of the best rums in the world that was produced in 2015 and stored in oak casks for exactly 6 years. See www.jorgepool.com for further info.