### PR TITLE
Add Policy ID for Kaleidoscope NFT Series

### DIFF
--- a/KaleidoscopeNFT
+++ b/KaleidoscopeNFT
@@ -1,11 +1,13 @@
 {
     "project": "Kaleidoscope NFT Series",
     "tags":[
-          "Kaleidoscope NFT Series"
+          "Kaleidoscope NFT Series",
+          "https://kaleidoscope-nft-series.com/"
           ],
     "policies": [
         "3422607f3faf23a9b1413df276e28039429ff949e6ff365676b1ef53",
         "22bb6895708e370515d232de61754533004f98b5f2edd963ea92a07e",
-        "33c9e1f05a7b354eed0ab2cc0293e2e17b07e319bf61c756659181eb"
+        "33c9e1f05a7b354eed0ab2cc0293e2e17b07e319bf61c756659181eb",
+        "92d61dbd5812cc57bbfefd7415864a41e11f16292ace537efee3c54c"
     ]
 }


### PR DESCRIPTION
Additional Policy ID for Lucid Tiles NFTs for The Kaleidoscope NFT Series Project

https://kaleidoscope-nft-series.com/

