### PR TITLE
Correction on the policy id of Uyikodelic

### DIFF
--- a/Uyikodelic
+++ b/Uyikodelic
@@ -1,0 +1,12 @@
+[
+  {
+    "project": "Uyikodelic",
+    "tags": [
+      "Uyikodelic", "Uyiko-delic"
+      ],
+    "policies": [
+      "5b38a55d5e3a9c7d635b75809c9cfa839a0baee072ea5ba997f1474a"
+
+    ]
+  }
+]


### PR DESCRIPTION
I put the wrong policy in the last file. This is the correct one.
Uyikodelic is a wonderful journey to review the Ukiyo-e style, the Japanese painting movement from the Edo period, from a psychedelic perspective.
Webpage: https://www.nftartisans.xyz/uyikodelic