### PR TITLE
Update Cardingo

### DIFF
--- a/Cardingo
+++ b/Cardingo
@@ -2,7 +2,7 @@
     {
         "project": "HoskeyChains",
         "policies": [
-            "3ce9e515b32e210d5069ffe188deb1b60ee4d0669e6a94aaedc06597"
+            "d734b1b17551d02bd255283b014b990d3403cb4e5d6c52a6da8dc72b"
         ]
     },
         {


### PR DESCRIPTION
Updated Hoskeychains with new PolicyID. Old PolicyID was used for Dev/test.

Change is validated through our Twitter:
https://twitter.com/cardingo_CNFTs/status/1457941752388538378?s=20