### PR TITLE
Added policy for Keys #10000 and #10001

### DIFF
--- a/CardanoKeys
+++ b/CardanoKeys
@@ -1,9 +1,17 @@
-{
-    "project": "CardanoKeys",
-    "tags": [
-        "CardanoKeys"
-    ],
-    "policies": [
-        "423aaa3a092aff29c00cef49fe0bef65abf7838226d6869ca9c44f24"
-    ]
-}
+[
+    {
+        "project": "CardanoKeys",
+        "tags": [
+            "CardanoKeys"
+        ],
+        "policies": [
+            "423aaa3a092aff29c00cef49fe0bef65abf7838226d6869ca9c44f24"
+        ]
+    },
+    {
+        "project": "CardanoKeys - Extended",
+        "policies": [
+            "bdf8c6170793a8d6c49089264e08dfe5cd589e1321393777150dd06e"
+        ]
+    }
+]


### PR DESCRIPTION
Added policy for the missing keys, published here:
https://twitter.com/cryptodelicsnft/status/1440665962219405317

It was a collaboration with glus for one of the two keys.
