### PR TITLE
Revert "Create Wall st Apes"

### DIFF
--- a/Wall st Apes
+++ b/Wall st Apes
@@ -1,8 +1,0 @@
-[
-{
-"project": "Wall st Apes",
-"policies": [
-"0735a6f68074aac8c0a5a7e186502c89981779298738a20bdab594e6"
-]
-}
-]


### PR DESCRIPTION
Reverts Cardano-NFTs/policyIDs#3434

This is the second of 2 that are duplicates.  First successful one seen here:  https://github.com/Cardano-NFTs/policyIDs/pull/3364

We currently have 2 active names with our NFT split among them at CNFT  (Wall Street Apes
![wallstapes error](https://user-images.githubusercontent.com/93738962/141701691-c78c8da5-c355-4a78-943b-5e3af1c9cd0d.jpg)
