### PR TITLE
Update PunkAss

### DIFF
--- a/PunkAss
+++ b/PunkAss
@@ -1,11 +1,18 @@
 [
 {
-    "project": "PunkAss",
+    "project": "PunkAss CP",
     "tags": [ "PunkAss"
     ],
     "policies": [
-        "332e8287a8aa7afca42ab7668b8b16ae912b01b4bdbf8a55fed6deea",
-        "ceada78dee004079d59296067a46baac3cd39745260a7d68da3c99d1"
+        "332e8287a8aa7afca42ab7668b8b16ae912b01b4bdbf8a55fed6deea"
+    ]
+},
+{
+    "project": "PunkAss S1",
+    "tags": [ "PunkAss"
+    ],
+    "policies": [
+        "f217f1369229c314c5377935f95097b4b10b83c779c53888e0b07f45"
     ]
 }
 ]


### PR DESCRIPTION
separating CP giveaways from the S1,
updating S1 Policy ID

The policy ID has been updated on the website.

Thank you very much for all your hard work!