### PR TITLE
Create CheffToken

### DIFF
--- a/projects/Cheff Token
+++ b/projects/Cheff Token
@@ -1,5 +1,8 @@
 {
-    "project": "CHEFF Token",
+    "project": "Cheff Token",
+    "tags": [
+        "Token", "SPO"
+    ],
     "policies": [
         "f10b16b705ef9baac04ca79c0da011633c8c20356b6a42262a1691da"
     ]

--- a/projects/CheffToken
+++ b/projects/CheffToken
@@ -1,0 +1,6 @@
+{
+    "project": "CHEFF Token",
+    "policies": [
+        "f10b16b705ef9baac04ca79c0da011633c8c20356b6a42262a1691da"
+    ]
+}


### PR DESCRIPTION
Add cheff token project to verification. Cheff Token are rewarded to all Cheff delegations and can be traded freely in Harmony when redeemed.
The token is backed by Cardano staking pool revenue and several cryptocurrencies.