### PR TITLE
Update PunkAss

### DIFF
--- a/projects/PunkAss
+++ b/projects/PunkAss
@@ -1,8 +1,6 @@
 [
 {
     "project": "PunkAss CP",
-    "tags": [ "PunkAss"
-    ],
     "policies": [
         "332e8287a8aa7afca42ab7668b8b16ae912b01b4bdbf8a55fed6deea",
         "6b60164463a2b3f0d8869f870cd5e9ac728db478232ab90c5fbf1c97"
@@ -10,8 +8,6 @@
 },
 {
     "project": "PunkAss S1",
-    "tags": [ "PunkAss"
-    ],
     "policies": [
         "f217f1369229c314c5377935f95097b4b10b83c779c53888e0b07f45"
     ]


### PR DESCRIPTION
I am trying to figure out why we have 3 different categories in punkass, and I am assuming it is the tags. for some reason our season 1 is split amongst two different groups. I am removing tags to see if it fixes it. thanks!