### PR TITLE
Adding our bitscoin policy ID

### DIFF
--- a/projects/anim8bits
+++ b/projects/anim8bits
@@ -1,3 +1,4 @@
+   [
         {
         "project": "Anim8Bits",
         "tags": [
@@ -12,4 +13,16 @@
             "3e54cc07d4c1f9dfb9332ce7c6c865efe6980cef4ec785aec4814b83",
             "804778fc7307fd9159f5894cd4f9d24eef84cb2ca092c3b60d8f36a7"
         ]
+    },
+            {
+        "project": "Bitscoin",
+        "tags": [
+            "Anim8bits",
+            "bitscoin",
+            "8tc"
+            ],
+        "policies": [
+            "81fd41215b08ab60f78dda8c076487f65228ace5bb9ca122e8bc05f4"
+        ]
     }
+]


### PR DESCRIPTION
Adding our bitscoin policy ID

Website is listed on the token:
Token: https://pool.pm/81fd41215b08ab60f78dda8c076487f65228ace5bb9ca122e8bc05f4.Bitscoin

Policy ID is also listed on the website
Website: https://bitscoin.dev/#info

Main anim8bits twitter is on the website footer button too.

Thanks!