### PR TITLE
Jerusalem map 1170DC

### DIFF
--- a/Jerusalem maps
+++ b/Jerusalem maps
@@ -1,0 +1,9 @@
+[
+  {
+    "project": "Historicmaps",
+    "policies": [
+      "policy1"
+    ]
+  }
+]
+


### PR DESCRIPTION
The most famous of eleven round Crusader maps of Jerusalem date back to 1170DC