### PR TITLE
Delete DeathSquadNFT

### DIFF
--- a/projects/DeathSquadNFT
+++ b/projects/DeathSquadNFT
@@ -1,9 +1,0 @@
-{
-    "project": "Death Squad",
-    "tags": [
-        "Death Squad"
-    ],
-    "policies": [
-        "fc88af875ddfc6ee00e2cf77099b2c88353291b580869db5fb87f92b"
-          ]
-}


### PR DESCRIPTION
This is a duplicate entry of https://github.com/Cardano-NFTs/policyIDs/blob/main/projects/DeathSquad

Its been causing some issues so removing this file for the other and also making a pull request on the other to update one of those policy IDs. with this one.

Website: https://deathsquad.co.uk/
Tweet of policy Id: https://twitter.com/DeathsquadNFT/status/1470443351509975042