### PR TITLE
Update Policy ID

### DIFF
--- a/projects/DeathSquad
+++ b/projects/DeathSquad
@@ -4,7 +4,7 @@
         "DeathSquad"
     ],
     "policies": [
-        "8fbc0e1050b3a15534eab8b532d90ae92d50b23f5f7c5e82d8249e74"
+        "fc88af875ddfc6ee00e2cf77099b2c88353291b580869db5fb87f92b"
     ]
 }, {
     "project": "Death Squad - Cute Squad",


### PR DESCRIPTION
One of the policy IDs was wrong on this file and there is a duplicate entry for this project. Can you help delete this file please: https://github.com/Cardano-NFTs/policyIDs/pull/4906

There are only two policy IDs for this project

Website: https://deathsquad.co.uk/
Tweet of policy Id: https://twitter.com/DeathsquadNFT/status/1470443351509975042