### PR TITLE
Registering Havoc Worlds

### DIFF
--- a/projects/Havoc Worlds
+++ b/projects/Havoc Worlds
@@ -1,0 +1,8 @@
+[
+  {
+    "project": "Havoc Worlds",
+    "policies": [
+      "1088b361c41f49906645cedeeb7a9ef0e0b793b1a2d24f623ea74876"
+    ]
+  }
+]


### PR DESCRIPTION
Proof: project website (early version) containing the policy ID:

[https://havocworlds.com/](https://havocworlds.com/)

