### PR TITLE
Updated the Cyberdemons project.

### DIFF
--- a/projects/Cyberdemons
+++ b/projects/Cyberdemons
@@ -2,7 +2,8 @@
   {
     "project": "Cyberdemons",
     "policies": [
-        "1de34a2ffd39d9130bc7d4fdb5fd678d95ede1469d4a0600a3fa6a31"
+        "1de34a2ffd39d9130bc7d4fdb5fd678d95ede1469d4a0600a3fa6a31",
+        "ecd4d22982d43a2f4a0fb73b31d9b69e8bb1bf010859cf915534fdf0"
     ]
   }
 ]


### PR DESCRIPTION
- Added the policy ID for collection two.
- Unstoppable Domain: cyberdemons.nft
- Standard Domain (current): https://bafybeicqn5dapsidtdl6tvpyztelhz573cc3eznnt3omtsah56xg63tjuu.ipfs.infura-ipfs.io
- Twitter: No associated account