### PR TITLE
Update blockowls

### DIFF
--- a/projects/blockowls
+++ b/projects/blockowls
@@ -1,10 +1,29 @@
 [
   {
     "project": "BlockOwls",
+    "tags": [
+        "BlockOwls Chapter 1 - GBOiC - Part 1 Hydra"
+    ],
     "policies": [
-        "bff82d31352d9bdfdb49e243ab74af715488631f330b2cf064178f90",
-        "3f4360edd7f689b637b44587150e71453a51ba29655336ff374c201c",
-        "62afb32c355614608390ccfd007f87fb06844cec373dba4ce8272184"
+      "bff82d31352d9bdfdb49e243ab74af715488631f330b2cf064178f90"
+    ]
+  },
+  {
+    "project": "BlockOwls",
+    "tags": [
+        "BlockOwls Chapter 1 - GBOiC - Tygar Collection"
+    ],
+    "policies": [
+      "3f4360edd7f689b637b44587150e71453a51ba29655336ff374c201c"
+    ]
+  }
+  {
+    "project": "BlockOwls",
+    "tags": [
+        "BlockOwls Chapter 1- GBOiC - Story Collection"
+    ],
+    "policies": [
+      "62afb32c355614608390ccfd007f87fb06844cec373dba4ce8272184"
     ]
   }
 ]

--- a/projects/blockowls
+++ b/projects/blockowls
@@ -16,7 +16,7 @@
     "policies": [
       "3f4360edd7f689b637b44587150e71453a51ba29655336ff374c201c"
     ]
-  }
+  },
   {
     "project": "BlockOwls",
     "tags": [


### PR DESCRIPTION
Adding tags to split out the different BlockOwls projects. Policy IDs remain the same and can be verified here:

https://www.blockowls.io/policyids