### PR TITLE
Add Christmas Truce Airdrop Policy ID

### DIFF
--- a/projects/ADA Army
+++ b/projects/ADA Army
@@ -6,7 +6,8 @@
       "AdaArmy"
     ],
     "policies": [
-      "d6fe6efa7788cb70e57a91891605e3694352cabb4837e870610300e9"
+      "d6fe6efa7788cb70e57a91891605e3694352cabb4837e870610300e9",
+      "a883d4a02f4c2cf0c5eeec0f13a5c3ab9a98a8b619cfe6df331eb515"
     ]
   }
 ]


### PR DESCRIPTION
Original and Airdrop policy IDs are displayed in the footer on: https://www.adaarmy.io/