### PR TITLE
Add ADA Army Utility Token Policy ID

### DIFF
--- a/projects/ADA Army
+++ b/projects/ADA Army
@@ -8,5 +8,15 @@
     "policies": [
       "d6fe6efa7788cb70e57a91891605e3694352cabb4837e870610300e9"
     ]
+  },
+  {
+    "project": "Ada Army Utility Token",
+    "tags": [
+      "ADA Army Utility Token",
+      "AdaArmyUtilityToken"
+    ],
+    "policies": [
+      "a883d4a02f4c2cf0c5eeec0f13a5c3ab9a98a8b619cfe6df331eb515"
+    ]
   }
 ]


### PR DESCRIPTION
Original and Utility Token policy IDs are displayed in the footer on: https://www.adaarmy.io/