### PR TITLE
Seperate policy's into two projects

### DIFF
--- a/projects/UglyBros
+++ b/projects/UglyBros
@@ -4,7 +4,15 @@
         "Ugly Bros"
         ],
     "policies": [
-         "12f9d9446c422caa870948bae1b8844c26c64958943a3954103b034f",
+         "12f9d9446c422caa870948bae1b8844c26c64958943a3954103b034f"
+    ]
+},
+{
+    "project": "Ugly Bros Xmas Drop 2021",
+    "tags": [
+        "Ugly Bros"
+        ],
+    "policies": [
          "89c9857b0239f8d1074a8f66038c6734297c18538613c710673ea7a6"
     ]
 }]


### PR DESCRIPTION
RetroNFTs on behalf of UglyBros

No policy ID's changed, just separating out the projects at the request of UglyBros team.

Nothing should need verifying again but the website here is you need: https://uglybrosnft.com/