### PR TITLE
Create DigitalWifee

### DIFF
--- a/projects/DigitalWifee
+++ b/projects/DigitalWifee
@@ -1,0 +1,8 @@
+[
+  {
+    "project": "!DigitalWifee",
+    "policies": [
+      "ee5af4719204bdff4f947d02535c890c136e6cf1a0545b1cc6984be7"
+    ]
+  }
+]


### PR DESCRIPTION
https://twitter.com/DigitalWifeNFTs

https://twitter.com/DigitalWifeNFTs/status/1483388485348249602

Everyone who minted on cardahub.io in that time i guess has this policy ID
Mine are only the ones with name: DigitalWife... cca 8 nfts
AnOnlineGuy — Today at 5:04 PM
that isn't possible
we not be verifying any of those policys
sorry
there are so many fakes under that policy
smartmoney — Today at 5:12 PM
Cause thats a lot of different people who minted there, I'm rather new to creating NFTs so I created it on cardahub and then putted that policyID in my first PR - that is my mistake, consequently all the NFT's minted on cardahub under that policy and listed on cnft were showing under my project !DigitalWifes,I reported this in comments of my PR. I just want my project back, I've minted now elsewhere and I have my own policyID.

