### PR TITLE
Added policy ID for La Zai the Sad Panda

### DIFF
--- a/projects/pandADA
+++ b/projects/pandADA
@@ -4,7 +4,8 @@
     "policies": [
       "ee2247e17b8d31ea81adddae22d7e8117cfb0a16ca4d973360ac05e0",
       "ef404e5e61f52cd57cb5414ede3ccbb731f988fcf5e91eafb1d61e32",
-      "ab1024c510e57cc74474f2ec10cb8d07beb16064927ef8a191c4e1f1"
+      "ab1024c510e57cc74474f2ec10cb8d07beb16064927ef8a191c4e1f1",
+      "1efc9e1b5fe1b5e28362ba98ba04a31e02b08d1f8221d61c7cd3f976"
     ]
   }
 ]


### PR DESCRIPTION
La Zai the Sad Panda can be traded 1 for 1 with CNFTs of rugpulled or discontinued panda-themed projects. Posted his policy ID in our Discord, as well as the following locations:

Website: https://testnet.pandada.io/generations/
Twitter: https://twitter.com/pandADA_nft/status/1488028972332072961?s=20&t=MQ8XlsIU00moE1A6qtJXvQ