### PR TITLE
Adding policyId for new Rebaked: Lobster frens collection

### DIFF
--- a/projects/GingerbreadSquad
+++ b/projects/GingerbreadSquad
@@ -25,5 +25,14 @@
         "policies": [
             "dae56e147ec0904379c86f1ee27195b26196afa2b15b5fecc538f96c"
         ]
+    },
+    {
+        "project": "Rebaked: Lobster frens",
+         "tags": [
+            "Gingerbread Squad", "Gingerbread", "Ginger", "Gingers", "Rebaked", "Lobster", "Lobster frens"
+        ],
+        "policies": [
+            "9df1b7979ae81f66c8e1caf040aed23fd1a0e074b597636636daf075"
+        ]
     }
 ]


### PR DESCRIPTION
Adding new policyId to our existing verified entries for the Rebaked: Lobster frens collection.

Official Twitter
https://twitter.com/Gingerbreadnft

Discord
https://discord.gg/WqukSH3FDR

Website
https://rebaked.io

New policyId is listed on our website (towards bottom of page)